### PR TITLE
[Fix] 백그라운드 위치 저장 및 알람 로직 수정

### DIFF
--- a/app/src/main/java/com/preonboarding/locationhistory/data/source/local/worker/LocationWorker.kt
+++ b/app/src/main/java/com/preonboarding/locationhistory/data/source/local/worker/LocationWorker.kt
@@ -13,6 +13,7 @@ import com.preonboarding.locationhistory.data.source.local.entity.LocationEntity
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.coroutineScope
+import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -41,7 +42,6 @@ class LocationWorker @AssistedInject constructor(
                 val date = Date(now)
                 val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
                 val time = simpleDateFormat.format(date)
-
                 if (latitude != null && longitude != null) {
                     val entity = LocationEntity(
                         id = 0,
@@ -49,7 +49,6 @@ class LocationWorker @AssistedInject constructor(
                         longitude = longitude.toFloat(),
                         date = time
                     )
-
                     locationRepository.saveLocation(location = entity)
                 }
                 Result.success()

--- a/app/src/main/java/com/preonboarding/locationhistory/presentation/custom/dialog/TimerFragmentDialog.kt
+++ b/app/src/main/java/com/preonboarding/locationhistory/presentation/custom/dialog/TimerFragmentDialog.kt
@@ -105,12 +105,19 @@ class TimerFragmentDialog : DialogFragment() {
 
                             val time: Long = binding.etTimer.text.toString().toLong()
 
-                            alarmManager?.setRepeating(
-                                AlarmManager.RTC,
-                                System.currentTimeMillis(),
-                                time * 1000 * 60,
-                                pendingIntent
-                            )
+                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                                alarmManager?.setExact(
+                                    AlarmManager.RTC_WAKEUP,
+                                    time * 1000 * 60,
+                                    pendingIntent
+                                )
+                            } else {
+                                alarmManager?.setExactAndAllowWhileIdle(
+                                    AlarmManager.RTC_WAKEUP,
+                                    time * 1000 * 60,
+                                    pendingIntent
+                                )
+                            }
                             delay(3_000)
                             dismiss()
                         }


### PR DESCRIPTION
반복 알람 -> 단일 알람이 다음 알람을 설정하도록 수정
앱이 죽었을 때 위치저장이 안되던 로직을 access background location 권한을 얻어서 앱이 죽어도 위치를 받아서 저장할 수 있도록 변경